### PR TITLE
[FIX] Output registration

### DIFF
--- a/boutiques_descriptors/qsiprep_v0_16_0rc3_4x.json
+++ b/boutiques_descriptors/qsiprep_v0_16_0rc3_4x.json
@@ -5,8 +5,8 @@
     "tool-version": "v0.16.0rc3_4x",
     "shell": "/bin/bash",
     "schema-version": "0.5",
-    "command-line": "qsiprep [SUBJECT_DIR] [OUTPUT_DIR] participant --skip_bids_validation --work-dir work [FS_LICENSE_FILE] --n_cpus 4 --mem_mb 15000 [ACQUISITION_TYPE] [INTERACTIVE_REPORTS_ONLY] [RECON_ONLY] [RECON_SPEC] [RECON_INPUT] [USE_PLUGIN] [ANAT_ONLY] [DWI_ONLY] [INFANT] [BOILERPLATE] [VERBOSE] [IGNORE] [LONGITUDINAL] [B0_THRESHOLD] [DWI_DENOISE_WINDOW] [UNRINGING_METHOD] [NO_B0_HARMONIZATION] [DENOISE_BEFORE_COMBINING] [DENOISE_AFTER_COMBINING] [COMBINE_ALL_DWIS] [SEPARATE_ALL_DWIS] [DISTORTION_GROUP_MERGE] [WRITE_LOCAL_BVECS] [OUTPUT_SPACE] [TEMPLATE] [OUTPUT_RESOLUTION] [B0_TO_T1W_TRANSFORM] [INTRAMODAL_TEMPLATE_ITERS] [INTRAMODAL_TEMPLATE_TRANSFORM] [B0_MOTION_CORR_TO] [HMC_TRANSFORM] [HMC_MODEL] [EDDY_CONFIG] [SHORELINE_ITERS] [IMPUTE_SLICE_THRESHOLD] [SKULL_STRIP_TEMPLATE] [SKULL_STRIP_FIXED_SEED] [FORCE_SPATIAL_NORMALIZATION] [SKIP_T1_BASED_SPATIAL_NORMALIZATION] [DO_RECONALL] [PREFER_DEDICATED_FMAPS] [FMAP_BSPLINE] [FMAP_NO_DEMEAN] [USE_SYN_SDC] [FORCE_SYN] [RESOURCE_MONITOR] [REPORTS_ONLY] [WRITE_GRAPH] [STOP_ON_FIRST_CRASH] [SLOPPY]",
-    "container-image": 
+    "command-line": "qsiprep [SUBJECT_DIR] [QSIPREP_OUTPUT_DIR] participant --skip_bids_validation --work-dir work [FS_LICENSE_FILE] --n_cpus 4 --mem_mb 15000 [ACQUISITION_TYPE] [INTERACTIVE_REPORTS_ONLY] [RECON_ONLY] [RECON_SPEC] [RECON_INPUT] [USE_PLUGIN] [ANAT_ONLY] [DWI_ONLY] [INFANT] [BOILERPLATE] [VERBOSE] [IGNORE] [LONGITUDINAL] [B0_THRESHOLD] [DWI_DENOISE_WINDOW] [UNRINGING_METHOD] [NO_B0_HARMONIZATION] [DENOISE_BEFORE_COMBINING] [DENOISE_AFTER_COMBINING] [COMBINE_ALL_DWIS] [SEPARATE_ALL_DWIS] [DISTORTION_GROUP_MERGE] [WRITE_LOCAL_BVECS] [OUTPUT_SPACE] [TEMPLATE] [OUTPUT_RESOLUTION] [B0_TO_T1W_TRANSFORM] [INTRAMODAL_TEMPLATE_ITERS] [INTRAMODAL_TEMPLATE_TRANSFORM] [B0_MOTION_CORR_TO] [HMC_TRANSFORM] [HMC_MODEL] [EDDY_CONFIG] [SHORELINE_ITERS] [IMPUTE_SLICE_THRESHOLD] [SKULL_STRIP_TEMPLATE] [SKULL_STRIP_FIXED_SEED] [FORCE_SPATIAL_NORMALIZATION] [SKIP_T1_BASED_SPATIAL_NORMALIZATION] [DO_RECONALL] [PREFER_DEDICATED_FMAPS] [FMAP_BSPLINE] [FMAP_NO_DEMEAN] [USE_SYN_SDC] [FORCE_SYN] [RESOURCE_MONITOR] [REPORTS_ONLY] [WRITE_GRAPH] [STOP_ON_FIRST_CRASH] [SLOPPY]",
+    "container-image":
     {
         "image": "pennbbl/qsiprep:0.16.0RC3",
         "index": "docker://",
@@ -27,7 +27,7 @@
         "members": [
             "interactive_reports_only"
          ],
-        "name": "Interactive Report Only Arguments" 
+        "name": "Interactive Report Only Arguments"
     },
     {
         "description": "Options for reconstructing qsiprep outputs",
@@ -37,7 +37,7 @@
             "recon_spec",
             "recon_input"
          ],
-        "name": "Reconstruction Arguments" 
+        "name": "Reconstruction Arguments"
     },
     {
         "description": "Options to handle performance",
@@ -50,7 +50,7 @@
             "boilerplate",
             "verbose"
          ],
-        "name": "Performance Arguments" 
+        "name": "Performance Arguments"
     },
     {
         "description": "Workflow Configuration",
@@ -71,7 +71,7 @@
             "template",
             "denoise_after_combining"
          ],
-        "name": "Workflow Configuration Arguments" 
+        "name": "Workflow Configuration Arguments"
     },
     {
         "description": "Options for dwi-to-T1w Coregistration",
@@ -87,7 +87,7 @@
             "shoreline_iters",
             "impute_slice_threshold"
          ],
-        "name": "dwi-to-T1w Coregistration Arguments" 
+        "name": "dwi-to-T1w Coregistration Arguments"
     },
     {
         "description": "Specific options for ANTs registrations",
@@ -98,7 +98,7 @@
             "force_spatial_normalization",
             "skip_t1_based_spatial_normalization"
          ],
-        "name": "ANTs Registrations Arguments" 
+        "name": "ANTs Registrations Arguments"
     },
     {
         "description": "Specific options for FreeSurfer preprocessing",
@@ -106,7 +106,7 @@
         "members": [
             "do_reconall"
          ],
-        "name": "FreeSurfer Preprocessing Arguments" 
+        "name": "FreeSurfer Preprocessing Arguments"
     },
     {
         "description": "Specific options for handling fieldmaps",
@@ -116,7 +116,7 @@
             "fmap_bspline",
             "fmap_no_demean"
          ],
-        "name": "Fieldmaps Arguments" 
+        "name": "Fieldmaps Arguments"
     },
     {
         "description": "Specific options for SyN distortion correction",
@@ -125,7 +125,7 @@
             "use_syn_sdc",
             "force_syn"
          ],
-        "name": "SyN Distortion Correction Arguments" 
+        "name": "SyN Distortion Correction Arguments"
     },
     {
         "description": "Other options",
@@ -137,8 +137,8 @@
             "stop_on_first_crash",
             "sloppy"
          ],
-        "name": "Other Options Arguments" 
-    }        
+        "name": "Other Options Arguments"
+    }
     ],
     "inputs": [
         {
@@ -155,7 +155,7 @@
             "name": "output_dir_name",
             "optional": false,
             "type": "String",
-            "value-key": "[OUTPUT_DIR]"
+            "value-key": "[QSIPREP_OUTPUT_DIR]"
         },
         {
             "command-line-flag": "--acquisition_type",
@@ -246,7 +246,7 @@
             "optional": true,
             "type": "Flag",
             "value-key": "[BOILERPLATE]"
-        }, 
+        },
         {
             "command-line-flag": "-vvv",
             "id": "verbose",
@@ -362,8 +362,8 @@
             "optional": true,
             "type": "String",
             "value-choices": [
-                "concat", 
-                "average", 
+                "concat",
+                "average",
                 "none"
             ],
             "value-key": "[DISTORTION_GROUP_MERGE]"
@@ -419,7 +419,7 @@
             "optional": true,
             "type": "String",
             "value-choices": [
-                "Rigid", 
+                "Rigid",
                 "Affine"
             ],
             "value-key": "[B0_TO_T1W_TRANSFORM]"
@@ -441,9 +441,9 @@
             "optional": true,
             "type": "String",
             "value-choices": [
-                "Rigid", 
-                "Affine", 
-                "BSplineSyN", 
+                "Rigid",
+                "Affine",
+                "BSplineSyN",
                 "SyN"
             ],
             "value-key": "[INTRAMODAL_TEMPLATE_TRANSFORM]"
@@ -482,8 +482,8 @@
             "optional": true,
             "type": "String",
             "value-choices":[
-                "none", 
-                "3dSHORE", 
+                "none",
+                "3dSHORE",
                 "eddy"
             ],
             "value-key": "[HMC_MODEL]"
@@ -523,7 +523,7 @@
             "optional": true,
             "type": "String",
             "value-choices":[
-                "OASIS", 
+                "OASIS",
                 "NKI"
             ],
             "value-key": "[SKULL_STRIP_TEMPLATE]"
@@ -554,7 +554,7 @@
             "optional": true,
             "type": "Flag",
             "value-key": "[SKIP_T1_BASED_SPATIAL_NORMALIZATION]"
-        }, 
+        },
         {
             "command-line-flag": "--fs-license-file",
             "id": "fs_license_file",
@@ -665,14 +665,15 @@
         }
     ],
     "output-files" : [{
-        "id" : "output_dir",
-        "name" : "Output Directory",
-        "description" : "This is the directory where the overall outputs are to be stored.",
-        "path-template" : "[OUTPUT_DIR]",
-        "optional" : false
-    }],
+            "id" : "output_dir",
+            "name" : "Output Directory",
+            "description" : "This is the directory where the overall outputs are to be stored.",
+            "path-template" : "[QSIPREP_OUTPUT_DIR]/[SUBJECT_DIR]/qsiprep/[SUBJECT_DIR]",
+            "optional" : false
+        }
+    ],
     "custom": {
-        "cbrain:readonly-input-files": true, 
+        "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:integrator_modules": {
             "BoutiquesFileTypeVerifier": {


### PR DESCRIPTION
Here is a version of the qsiprep able to register `subject-x` present in `qsiprep` output. 