### PR TITLE
Added cleanup of workdir temp files in NiBabies

### DIFF
--- a/boutiques_descriptors/NiBabies_22_1_3.json
+++ b/boutiques_descriptors/NiBabies_22_1_3.json
@@ -739,6 +739,10 @@
               "infant_freesurfer_output_dir": "derivatives/infant-freesurfer"
             },
             "BoutiquesBidsSingleSubjectMaker": "subject_dir",
+            "BoutiquesPostProcessingCleaner": [
+              "work",
+              "[OUTPUT_DIR]"
+            ],
             "BoutiquesInputSubdirMaker": {
               "cabinet_output":      {"dirname": "precomputed",                                         "append_filename": false},
               "cabinet_output_json": {"dirname": "precomputed", "filename": "dataset_description.json", "append_filename": false}


### PR DESCRIPTION
I have examined some NiBabies work directories after the jobs were successful at MSI, and they were using more than 100GB of disk space!

This fix configures the CBRAIN execution layer to erase two subdirectories in the work directory, when the task completes successfully.