### PR TITLE
Adjusted QSIPrep QC tool interface

### DIFF
--- a/boutiques_descriptors/qsiprep_qc_v1_0.json
+++ b/boutiques_descriptors/qsiprep_qc_v1_0.json
@@ -3,7 +3,7 @@
     "schema-version": "0.5",
     "tool-version": "1.0",
     "url": "https://github.com/DCAN-Labs/QSIPREP_HBCD_QC",
-    "command-line": "qsiprep_qc [QSIPREPDirectory] [OutputDirectoryName] participant [ParticipantLabel] [SessionLabel] [BIDSSubjectDirectory]",
+    "command-line": "qsiprep_qc [QSIPREPDirectory] [OutputDirectoryName] participant [ParticipantLabel] [SessionLabel]",
     "description": "Simple pipeline to make summary QC images based on qsiprep outputs.",
     "inputs": [
       {
@@ -21,15 +21,6 @@
         "optional": false,
         "type": "String",
         "value-key": "[OutputDirectoryName]"
-    },
-    {
-        "command-line-flag": "--bids_directory",
-        "description": "BIDS Subject. This is not actually used in any way during processing.",
-        "id": "BIDSSubjectDirectory",
-        "name": "BIDSSubjectDirectory",
-        "optional": true,
-        "type": "File",
-        "value-key": "[BIDSSubjectDirectory]"
     },
     {
         "command-line-flag": "--participant-label",
@@ -54,7 +45,7 @@
         "id" : "OutputDirectory",
         "name" : "Output Directory",
         "description": "The output directory to store outcomes of preprocessing and reports",
-        "path-template" : "[OutputDirectoryName]/[QSIPREPDirectory]",
+        "path-template" : "[OutputDirectoryName]/sub-*",
         "optional" : false
     }],
     "suggested-resources": {
@@ -83,12 +74,10 @@
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],
         "cbrain:integrator_modules": {
             "BoutiquesFileTypeVerifier": {
-                "QSIPREPDirectory": [ "QsiprepOutput"],
-                "SubjectDirectory": [ "BIDSSubjectDirectory"]
+                "QSIPREPDirectory": [ "QsiprepOutput"]
             },
             "BoutiquesFileNameMatcher": {
-                "QSIPREPDirectory": "^sub-[a-zA-Z0-9_]+$",
-                "BIDSSubjectDirectory": "^sub-[a-zA-Z0-9_]+$"
+                "QSIPREPDirectory": "^sub-[a-zA-Z0-9_]+$"
             },
             "BoutiquesOutputFileTypeSetter": {
                 "OutputDirectory": "QsiprepQcOutput"
@@ -96,8 +85,6 @@
             "BoutiquesForcedOutputBrowsePath" : {
               "OutputDirectory": "derivatives/qsiprep_qc"
             },
-            "BoutiquesBidsSingleSubjectMaker": "BIDSSubjectDirectory",
-            "BoutiquesBidsSubjectSubsetter": { "BIDSSubjectDirectory": "all_to_keep"},
             "BoutiquesInputSubdirMaker": {
               "QSIPREPDirectory":     {"dirname": "qsiprep", "append_filename": false}
             }


### PR DESCRIPTION
* removed completely support for unnecessary and optional --bids_directory
* removed module BidsSingleSubjectMaker since the inputs is not a BIDS Subject
* adjusted the output path template since the input is automatically transformed into the constant string 'qsiprep' internally.