### PR TITLE
Fixed bug in OSPREY 4.2.1 BTQ modules

### DIFF
--- a/boutiques_descriptors/osprey_v4_2_1.json
+++ b/boutiques_descriptors/osprey_v4_2_1.json
@@ -203,14 +203,14 @@
           "SubjectDirectory": "all_to_keep"
         },
         "BoutiquesBidsSingleSubjectMaker": "SubjectDirectory",
+        "BoutiquesPostProcessingCleaner": [
+          ["[OSPREYOutputDirectoryName]", "[SubjectDirectory]", "[CabinetOutput]"]
+        ],
         "BoutiquesInputSubdirMaker": {
           "CabinetOutput": {
             "dirname": "precomputed",
             "append_filename": false
           },
-          "BoutiquesPostProcessingCleaner": [
-            ["[OSPREYOutputDirectoryName]", "[SubjectDirectory]", "[CabinetOutput]"]
-          ],
           "CabinetOutputJson": {
             "dirname": "precomputed",
             "filename": "dataset_description.json",


### PR DESCRIPTION
This is critical. Not a security issue, but the bug causes internal errors within the CBRAIN server that eventually leads to IP banning for Erik and Monalisa.