### PR TITLE
Added validation exception for a String

### DIFF
--- a/boutiques_descriptors/osprey_v4_2_1.json
+++ b/boutiques_descriptors/osprey_v4_2_1.json
@@ -171,6 +171,9 @@
       "cbrain:no-run-id-for-outputs": [
         "OutputDirectory"
       ],
+      "cbrain:override-input-string-ruby-regex": {
+        "LocSearchTerm": ":basename-pattern:"
+      },
       "cbrain:integrator_modules":    {
         "BoutiquesFileTypeVerifier": {
           "SubjectDirectory": [


### PR DESCRIPTION
We have added some new validation code for inputs of type String.

This particular input filed, "LocSearchTerm", often is filled with a value that contains asterisks (*), and so to allow them we have a particular validation class of characters that work, known as "basename-pattern".