### PR TITLE
allow spaces in nibabies (frmiprep) spaces param 

### DIFF
--- a/boutiques_descriptors/MADE_pipeline_v0p1.json
+++ b/boutiques_descriptors/MADE_pipeline_v0p1.json
@@ -108,7 +108,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p2.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p2.json
@@ -108,7 +108,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p3.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p3.json
@@ -108,7 +108,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p3p1.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p3p1.json
@@ -108,7 +108,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p4p1.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p4p1.json
@@ -108,7 +108,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p4p2.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p4p2.json
@@ -108,7 +108,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p4p4.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p4p4.json
@@ -108,7 +108,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p5p1.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p5p1.json
@@ -108,7 +108,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p5p2.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p5p2.json
@@ -108,7 +108,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p5p3.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p5p3.json
@@ -116,7 +116,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p5p5.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p5p5.json
@@ -116,7 +116,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p5p6.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p5p6.json
@@ -116,7 +116,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p6p0.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p6p0.json
@@ -116,7 +116,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/MADE_pipeline_v1p6p1.json
+++ b/boutiques_descriptors/MADE_pipeline_v1p6p1.json
@@ -116,7 +116,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/NiBabies_22_1_3.json
+++ b/boutiques_descriptors/NiBabies_22_1_3.json
@@ -727,7 +727,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:",
             "output_spaces": ":ids-with-spaces:"
         },

--- a/boutiques_descriptors/NiBabies_22_1_3.json
+++ b/boutiques_descriptors/NiBabies_22_1_3.json
@@ -728,7 +728,8 @@
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
         "cbrain:override-string-input-ruby-regex": {
-            "derivatives_prefix": ":relative-path:"
+            "derivatives_prefix": ":relative-path:",
+            "output_spaces": ":ids-with-spaces:"
         },
         "cbrain:no-run-id-for-outputs": [ "nibabies_output_dir", "nibabies_html_report", "infant_freesurfer_output_dir"],
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/NiBabies_24_0_0a1.json
+++ b/boutiques_descriptors/NiBabies_24_0_0a1.json
@@ -758,7 +758,8 @@
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
         "cbrain:override-string-input-ruby-regex": {
-            "derivatives_prefix": ":relative-path:"
+            "derivatives_prefix": ":relative-path:",
+            "output_spaces": ":ids-with-spaces:"
         },
         "cbrain:no-run-id-for-outputs": [ "nibabies_output_dir", "nibabies_html_report", "freesurfer_output_dir", "mcribs_output_dir"],
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/NiBabies_24_0_0a1.json
+++ b/boutiques_descriptors/NiBabies_24_0_0a1.json
@@ -757,7 +757,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:",
             "output_spaces": ":ids-with-spaces:"
         },

--- a/boutiques_descriptors/NiBabies_SingleAnat.json
+++ b/boutiques_descriptors/NiBabies_SingleAnat.json
@@ -751,7 +751,8 @@
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
         "cbrain:override-string-input-ruby-regex": {
-            "derivatives_prefix": ":relative-path:"
+            "derivatives_prefix": ":relative-path:",
+            "output_spaces": ":ids-with-spaces:"
         },
         "cbrain:no-run-id-for-outputs": [ "nibabies_output_dir", "nibabies_html_report", "freesurfer_output_dir"],
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/NiBabies_SingleAnat.json
+++ b/boutiques_descriptors/NiBabies_SingleAnat.json
@@ -750,7 +750,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:",
             "output_spaces": ":ids-with-spaces:"
         },

--- a/boutiques_descriptors/Nibabies_24.0.0rc0.json
+++ b/boutiques_descriptors/Nibabies_24.0.0rc0.json
@@ -720,7 +720,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:",
             "output_spaces": ":ids-with-spaces:"
         },

--- a/boutiques_descriptors/Nibabies_24.0.0rc0.json
+++ b/boutiques_descriptors/Nibabies_24.0.0rc0.json
@@ -721,7 +721,8 @@
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
         "cbrain:override-string-input-ruby-regex": {
-            "derivatives_prefix": ":relative-path:"
+            "derivatives_prefix": ":relative-path:",
+            "output_spaces": ":ids-with-spaces:"
         },
         "cbrain:no-run-id-for-outputs": [ "nibabies_output_dir", "nibabies_html_report", "freesurfer_output_dir", "mcribs_output_dir"],
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/Nibabies_24.1.0.json
+++ b/boutiques_descriptors/Nibabies_24.1.0.json
@@ -720,7 +720,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:",
             "output_spaces": ":ids-with-spaces:"
         },

--- a/boutiques_descriptors/Nibabies_24.1.0.json
+++ b/boutiques_descriptors/Nibabies_24.1.0.json
@@ -721,7 +721,8 @@
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
         "cbrain:override-string-input-ruby-regex": {
-            "derivatives_prefix": ":relative-path:"
+            "derivatives_prefix": ":relative-path:",
+            "output_spaces": ":ids-with-spaces:"
         },
         "cbrain:no-run-id-for-outputs": [ "nibabies_output_dir", "nibabies_html_report", "freesurfer_output_dir", "mcribs_output_dir"],
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/Nibabies_25.0.0a1.json
+++ b/boutiques_descriptors/Nibabies_25.0.0a1.json
@@ -739,7 +739,8 @@
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
         "cbrain:override-string-input-ruby-regex": {
-            "derivatives_prefix": ":relative-path:"
+            "derivatives_prefix": ":relative-path:",
+            "output_spaces": ":ids-with-spaces:"
         },
         "cbrain:no-run-id-for-outputs": [ "nibabies_output_dir", "nibabies_html_report", "freesurfer_output_dir", "mcribs_output_dir"],
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/Nibabies_25.0.0a1.json
+++ b/boutiques_descriptors/Nibabies_25.0.0a1.json
@@ -738,7 +738,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:",
             "output_spaces": ":ids-with-spaces:"
         },

--- a/boutiques_descriptors/Nibabies_25.0.0a2.json
+++ b/boutiques_descriptors/Nibabies_25.0.0a2.json
@@ -748,7 +748,8 @@
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
         "cbrain:override-string-input-ruby-regex": {
-            "derivatives_prefix": ":relative-path:"
+            "derivatives_prefix": ":relative-path:",
+            "output_spaces": ":ids-with-spaces:"
         },
         "cbrain:no-run-id-for-outputs": [ "nibabies_output_dir", "nibabies_html_report", "freesurfer_output_dir", "mcribs_output_dir"],
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/Nibabies_25.0.0a2.json
+++ b/boutiques_descriptors/Nibabies_25.0.0a2.json
@@ -747,7 +747,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:",
             "output_spaces": ":ids-with-spaces:"
         },

--- a/boutiques_descriptors/Nibabies_25.0.0a3.json
+++ b/boutiques_descriptors/Nibabies_25.0.0a3.json
@@ -747,9 +747,9 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:",
-            "output_spaces": "F"
+            "output_spaces": ":ids-with-spaces:"
         },
         "cbrain:no-run-id-for-outputs": [ "nibabies_output_dir", "nibabies_html_report", "freesurfer_output_dir", "mcribs_output_dir"],
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/Nibabies_25.0.0a3.json
+++ b/boutiques_descriptors/Nibabies_25.0.0a3.json
@@ -748,7 +748,8 @@
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
         "cbrain:override-string-input-ruby-regex": {
-            "derivatives_prefix": ":relative-path:"
+            "derivatives_prefix": ":relative-path:",
+            "output_spaces": "F"
         },
         "cbrain:no-run-id-for-outputs": [ "nibabies_output_dir", "nibabies_html_report", "freesurfer_output_dir", "mcribs_output_dir"],
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/Nibabies_25.0.0rc1.json
+++ b/boutiques_descriptors/Nibabies_25.0.0rc1.json
@@ -748,7 +748,8 @@
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
         "cbrain:override-string-input-ruby-regex": {
-            "derivatives_prefix": ":relative-path:"
+            "derivatives_prefix": ":relative-path:",
+            "output_spaces": ":ids-with-spaces:"
         },
         "cbrain:no-run-id-for-outputs": [ "nibabies_output_dir", "nibabies_html_report", "freesurfer_output_dir", "mcribs_output_dir"],
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/Nibabies_25.0.0rc1.json
+++ b/boutiques_descriptors/Nibabies_25.0.0rc1.json
@@ -747,7 +747,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:",
             "output_spaces": ":ids-with-spaces:"
         },

--- a/boutiques_descriptors/Nibabies_25.0.2.json
+++ b/boutiques_descriptors/Nibabies_25.0.2.json
@@ -748,7 +748,8 @@
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
         "cbrain:override-string-input-ruby-regex": {
-            "derivatives_prefix": ":relative-path:"
+            "derivatives_prefix": ":relative-path:",
+            "output_spaces": ":ids-with-spaces:"
         },
         "cbrain:no-run-id-for-outputs": [ "nibabies_output_dir", "nibabies_html_report", "freesurfer_output_dir", "mcribs_output_dir"],
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/Nibabies_25.0.2.json
+++ b/boutiques_descriptors/Nibabies_25.0.2.json
@@ -747,7 +747,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:",
             "output_spaces": ":ids-with-spaces:"
         },

--- a/boutiques_descriptors/Nibabies_25.2.0-0f306a2f.json
+++ b/boutiques_descriptors/Nibabies_25.2.0-0f306a2f.json
@@ -220,7 +220,8 @@
         "derivatives_prefix"
       ],
       "cbrain:override-string-input-ruby-regex": {
-        "derivatives_prefix": ":relative-path:"
+        "derivatives_prefix": ":relative-path:",
+        "output_spaces": ":ids-with-spaces:"
       },
       "cbrain:no-run-id-for-outputs": [
         "nibabies_output_dir",

--- a/boutiques_descriptors/Nibabies_25.2.0-0f306a2f.json
+++ b/boutiques_descriptors/Nibabies_25.2.0-0f306a2f.json
@@ -219,7 +219,7 @@
       "cbrain:allow_empty_strings":   [
         "derivatives_prefix"
       ],
-      "cbrain:override-string-input-ruby-regex": {
+      "cbrain:override-input-string-ruby-regex": {
         "derivatives_prefix": ":relative-path:",
         "output_spaces": ":ids-with-spaces:"
       },

--- a/boutiques_descriptors/Nibabies_25.2.0-2afa9081.json
+++ b/boutiques_descriptors/Nibabies_25.2.0-2afa9081.json
@@ -212,7 +212,10 @@
       "cbrain:allow_empty_strings":   [
         "derivatives_prefix"
       ],
-      "cbrain:override-string-input-ruby-regex": {                                                                         "derivatives_prefix": ":relative-path:"                                                                          },
+      "cbrain:override-string-input-ruby-regex": {
+        "derivatives_prefix": ":relative-path:",
+        "output_spaces": ":ids-with-spaces:"
+      },
       "cbrain:no-run-id-for-outputs": [
         "nibabies_output_dir",
         "nibabies_html_report",

--- a/boutiques_descriptors/Nibabies_25.2.0-2afa9081.json
+++ b/boutiques_descriptors/Nibabies_25.2.0-2afa9081.json
@@ -212,7 +212,7 @@
       "cbrain:allow_empty_strings":   [
         "derivatives_prefix"
       ],
-      "cbrain:override-string-input-ruby-regex": {
+      "cbrain:override-input-string-ruby-regex": {
         "derivatives_prefix": ":relative-path:",
         "output_spaces": ":ids-with-spaces:"
       },

--- a/boutiques_descriptors/XCP-D_0.12.0_0f306a2f-0ef9c88a.json
+++ b/boutiques_descriptors/XCP-D_0.12.0_0f306a2f-0ef9c88a.json
@@ -429,7 +429,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir"],

--- a/boutiques_descriptors/XCP-D_0.12.0_2afa9081-0ef9c88a.json
+++ b/boutiques_descriptors/XCP-D_0.12.0_2afa9081-0ef9c88a.json
@@ -429,7 +429,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir"],

--- a/boutiques_descriptors/XCP-D_0_10_1.json
+++ b/boutiques_descriptors/XCP-D_0_10_1.json
@@ -419,7 +419,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir", "xcpd_ses_summary_html_report", "xcpd_sub_summary_html_report"],

--- a/boutiques_descriptors/XCP-D_0_10_4.json
+++ b/boutiques_descriptors/XCP-D_0_10_4.json
@@ -419,7 +419,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir", "xcpd_ses_summary_html_report", "xcpd_sub_summary_html_report"],

--- a/boutiques_descriptors/XCP-D_0_10_5.json
+++ b/boutiques_descriptors/XCP-D_0_10_5.json
@@ -419,7 +419,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir", "xcpd_ses_summary_html_report", "xcpd_sub_summary_html_report"],

--- a/boutiques_descriptors/XCP-D_0_10_6.json
+++ b/boutiques_descriptors/XCP-D_0_10_6.json
@@ -419,7 +419,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir", "xcpd_ses_summary_html_report", "xcpd_sub_summary_html_report"],

--- a/boutiques_descriptors/XCP-D_0_1_3.json
+++ b/boutiques_descriptors/XCP-D_0_1_3.json
@@ -333,7 +333,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir", "xcpd_ses_summary_html_report", "xcpd_sub_summary_html_report"],

--- a/boutiques_descriptors/XCP-D_0_4_0rc2.json
+++ b/boutiques_descriptors/XCP-D_0_4_0rc2.json
@@ -360,7 +360,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir", "xcpd_ses_summary_html_report", "xcpd_sub_summary_html_report"],

--- a/boutiques_descriptors/XCP-D_0_6_1.json
+++ b/boutiques_descriptors/XCP-D_0_6_1.json
@@ -410,7 +410,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir", "xcpd_ses_summary_html_report", "xcpd_sub_summary_html_report"],

--- a/boutiques_descriptors/XCP-D_0_6_2.json
+++ b/boutiques_descriptors/XCP-D_0_6_2.json
@@ -409,7 +409,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir", "xcpd_ses_summary_html_report", "xcpd_sub_summary_html_report"],

--- a/boutiques_descriptors/XCP-D_0_7_1.json
+++ b/boutiques_descriptors/XCP-D_0_7_1.json
@@ -409,7 +409,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir", "xcpd_ses_summary_html_report", "xcpd_sub_summary_html_report"],

--- a/boutiques_descriptors/XCP-D_0_8_0.json
+++ b/boutiques_descriptors/XCP-D_0_8_0.json
@@ -400,7 +400,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir", "xcpd_ses_summary_html_report", "xcpd_sub_summary_html_report"],

--- a/boutiques_descriptors/XCP-D_0_8_1.json
+++ b/boutiques_descriptors/XCP-D_0_8_1.json
@@ -401,7 +401,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Natacha Beck <nbeck@mcin.ca>, Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "xcpd_output_dir", "xcpd_ses_summary_html_report", "xcpd_sub_summary_html_report"],

--- a/boutiques_descriptors/bibsnet_3_0_2.json
+++ b/boutiques_descriptors/bibsnet_3_0_2.json
@@ -95,7 +95,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": ["output_dir"],

--- a/boutiques_descriptors/bibsnetfull_3_4_1.json
+++ b/boutiques_descriptors/bibsnetfull_3_4_1.json
@@ -102,7 +102,7 @@
       "cbrain:allow_empty_strings":   [
         "derivatives_prefix"
       ],
-      "cbrain:override-string-input-ruby-regex": {
+      "cbrain:override-input-string-ruby-regex": {
         "derivatives_prefix": ":relative-path:"
       },
       "cbrain:no-run-id-for-outputs": [

--- a/boutiques_descriptors/bibsnetfull_3_6_0.json
+++ b/boutiques_descriptors/bibsnetfull_3_6_0.json
@@ -102,7 +102,7 @@
       "cbrain:allow_empty_strings":   [
         "derivatives_prefix"
       ],
-      "cbrain:override-string-input-ruby-regex": {
+      "cbrain:override-input-string-ruby-regex": {
         "derivatives_prefix": ":relative-path:"
       },
       "cbrain:no-run-id-for-outputs": [

--- a/boutiques_descriptors/bibsnetpt1_3_0_1.json
+++ b/boutiques_descriptors/bibsnetpt1_3_0_1.json
@@ -96,7 +96,7 @@
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:no-run-id-for-outputs": ["working_dir"],
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/bibsnetpt1_3_0_2.json
+++ b/boutiques_descriptors/bibsnetpt1_3_0_2.json
@@ -111,7 +111,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": ["working_dir"],

--- a/boutiques_descriptors/bibsnetpt1_3_1_2.json
+++ b/boutiques_descriptors/bibsnetpt1_3_1_2.json
@@ -111,7 +111,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": ["working_dir"],

--- a/boutiques_descriptors/bibsnetpt1_3_4_1.json
+++ b/boutiques_descriptors/bibsnetpt1_3_4_1.json
@@ -102,7 +102,7 @@
       "cbrain:allow_empty_strings":   [
         "derivatives_prefix"
       ],
-      "cbrain:override-string-input-ruby-regex": {
+      "cbrain:override-input-string-ruby-regex": {
         "derivatives_prefix": ":relative-path:"
       },
       "cbrain:no-run-id-for-outputs": [

--- a/boutiques_descriptors/bmex_1.0.5.json
+++ b/boutiques_descriptors/bmex_1.0.5.json
@@ -77,7 +77,7 @@
       "cbrain:allow_empty_strings":   [
         "derivatives_prefix"
       ],
-      "cbrain:override-string-input-ruby-regex": {
+      "cbrain:override-input-string-ruby-regex": {
         "derivatives_prefix": ":relative-path:"
       },
       "cbrain:no-run-id-for-outputs": [

--- a/boutiques_descriptors/cabinet.json
+++ b/boutiques_descriptors/cabinet.json
@@ -94,7 +94,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": ["precomputed_output_dir"],

--- a/boutiques_descriptors/cabinet_2_4_0.json
+++ b/boutiques_descriptors/cabinet_2_4_0.json
@@ -94,7 +94,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": ["output_dir"],

--- a/boutiques_descriptors/cabinet_2_4_2.json
+++ b/boutiques_descriptors/cabinet_2_4_2.json
@@ -94,7 +94,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": ["output_dir"],

--- a/boutiques_descriptors/cabinet_2_4_3.json
+++ b/boutiques_descriptors/cabinet_2_4_3.json
@@ -94,7 +94,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": ["output_dir"],

--- a/boutiques_descriptors/cabinet_2_4_4.json
+++ b/boutiques_descriptors/cabinet_2_4_4.json
@@ -94,7 +94,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": ["output_dir"],

--- a/boutiques_descriptors/hbcd_motion_1.0.0.json
+++ b/boutiques_descriptors/hbcd_motion_1.0.0.json
@@ -126,7 +126,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir"],

--- a/boutiques_descriptors/hbcd_motion_1_0.json
+++ b/boutiques_descriptors/hbcd_motion_1_0.json
@@ -117,7 +117,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir"],

--- a/boutiques_descriptors/hbcd_motion_1_1.json
+++ b/boutiques_descriptors/hbcd_motion_1_1.json
@@ -126,7 +126,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir"],

--- a/boutiques_descriptors/hbcd_qc_1_0_1.json
+++ b/boutiques_descriptors/hbcd_qc_1_0_1.json
@@ -71,7 +71,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir"],

--- a/boutiques_descriptors/hbcd_qc_1_0_2.json
+++ b/boutiques_descriptors/hbcd_qc_1_0_2.json
@@ -72,7 +72,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir"],

--- a/boutiques_descriptors/hbcd_qc_1_1_0.json
+++ b/boutiques_descriptors/hbcd_qc_1_1_0.json
@@ -72,7 +72,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir"],

--- a/boutiques_descriptors/mancorrbibsnet_1_0.json
+++ b/boutiques_descriptors/mancorrbibsnet_1_0.json
@@ -81,7 +81,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/mancorrbibsnet_1_1.json
+++ b/boutiques_descriptors/mancorrbibsnet_1_1.json
@@ -81,7 +81,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/mancorrbibsnet_3_4_1.json
+++ b/boutiques_descriptors/mancorrbibsnet_3_4_1.json
@@ -102,7 +102,7 @@
       "cbrain:allow_empty_strings":   [
         "derivatives_prefix"
       ],
-      "cbrain:override-string-input-ruby-regex": {
+      "cbrain:override-input-string-ruby-regex": {
         "derivatives_prefix": ":relative-path:"
       },
       "cbrain:no-run-id-for-outputs": [

--- a/boutiques_descriptors/mriqc_22_0_1.json
+++ b/boutiques_descriptors/mriqc_22_0_1.json
@@ -163,7 +163,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir"],

--- a/boutiques_descriptors/mrsqc_v4_2.json
+++ b/boutiques_descriptors/mrsqc_v4_2.json
@@ -94,7 +94,7 @@
     "cbrain:allow_empty_strings":   [
       "derivatives_prefix"
     ],
-    "cbrain:override-string-input-ruby-regex": {
+    "cbrain:override-input-string-ruby-regex": {
       "derivatives_prefix": ":relative-path:"
     },
     "cbrain:no-run-id-for-outputs": [

--- a/boutiques_descriptors/mrsqc_v4_2_1.json
+++ b/boutiques_descriptors/mrsqc_v4_2_1.json
@@ -94,7 +94,7 @@
     "cbrain:allow_empty_strings":   [
       "derivatives_prefix"
     ],
-    "cbrain:override-string-input-ruby-regex": {
+    "cbrain:override-input-string-ruby-regex": {
       "derivatives_prefix": ":relative-path:"
     },
     "cbrain:no-run-id-for-outputs": [

--- a/boutiques_descriptors/osprey_v1p1.json
+++ b/boutiques_descriptors/osprey_v1p1.json
@@ -118,7 +118,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/osprey_v2_2_1.json
+++ b/boutiques_descriptors/osprey_v2_2_1.json
@@ -119,7 +119,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/osprey_v2_2_2.json
+++ b/boutiques_descriptors/osprey_v2_2_2.json
@@ -128,7 +128,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/osprey_v2_3_0.json
+++ b/boutiques_descriptors/osprey_v2_3_0.json
@@ -147,7 +147,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/osprey_v2_4_0.json
+++ b/boutiques_descriptors/osprey_v2_4_0.json
@@ -156,7 +156,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/osprey_v2_4_1.json
+++ b/boutiques_descriptors/osprey_v2_4_1.json
@@ -156,7 +156,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/osprey_v2_4_3.json
+++ b/boutiques_descriptors/osprey_v2_4_3.json
@@ -168,7 +168,7 @@
       "cbrain:allow_empty_strings":   [
         "derivatives_prefix"
       ],
-      "cbrain:override-string-input-ruby-regex": {
+      "cbrain:override-input-string-ruby-regex": {
         "derivatives_prefix": ":relative-path:"
       },
       "cbrain:no-run-id-for-outputs": [

--- a/boutiques_descriptors/osprey_v2p0.json
+++ b/boutiques_descriptors/osprey_v2p0.json
@@ -119,7 +119,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/osprey_v2p1.json
+++ b/boutiques_descriptors/osprey_v2p1.json
@@ -119,7 +119,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/osprey_v4_2.json
+++ b/boutiques_descriptors/osprey_v4_2.json
@@ -168,7 +168,7 @@
       "cbrain:allow_empty_strings":   [
         "derivatives_prefix"
       ],
-      "cbrain:override-string-input-ruby-regex": {
+      "cbrain:override-input-string-ruby-regex": {
         "derivatives_prefix": ":relative-path:"
       },
       "cbrain:no-run-id-for-outputs": [

--- a/boutiques_descriptors/osprey_v4_2_1.json
+++ b/boutiques_descriptors/osprey_v4_2_1.json
@@ -168,7 +168,7 @@
       "cbrain:allow_empty_strings":   [
         "derivatives_prefix"
       ],
-      "cbrain:override-string-input-ruby-regex": {
+      "cbrain:override-input-string-ruby-regex": {
         "derivatives_prefix": ":relative-path:",
         "LocSearchTerm": ":basename-pattern:"
       },

--- a/boutiques_descriptors/qmri_postproc_v1_3_3.json
+++ b/boutiques_descriptors/qmri_postproc_v1_3_3.json
@@ -118,7 +118,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/qsiprep-bids-pipeline_v0.15.3.json
+++ b/boutiques_descriptors/qsiprep-bids-pipeline_v0.15.3.json
@@ -684,7 +684,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:integrator_modules": {

--- a/boutiques_descriptors/qsiprep_qc_v1_0.json
+++ b/boutiques_descriptors/qsiprep_qc_v1_0.json
@@ -90,7 +90,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/qsiprep_qc_v1_1.json
+++ b/boutiques_descriptors/qsiprep_qc_v1_1.json
@@ -90,7 +90,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/qsiprep_qc_v1_2.json
+++ b/boutiques_descriptors/qsiprep_qc_v1_2.json
@@ -88,7 +88,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/qsiprep_qc_v1_3.json
+++ b/boutiques_descriptors/qsiprep_qc_v1_3.json
@@ -88,7 +88,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/qsiprep_v0_16_0rc3_4x.json
+++ b/boutiques_descriptors/qsiprep_v0_16_0rc3_4x.json
@@ -697,7 +697,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir", "qsiprep_html_report" ],

--- a/boutiques_descriptors/qsiprep_v0_16_1-sel.json
+++ b/boutiques_descriptors/qsiprep_v0_16_1-sel.json
@@ -697,7 +697,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir", "qsiprep_html_report" ],

--- a/boutiques_descriptors/qsiprep_v0_16_1.json
+++ b/boutiques_descriptors/qsiprep_v0_16_1.json
@@ -697,7 +697,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir", "qsiprep_html_report" ],

--- a/boutiques_descriptors/qsiprep_v0_20_0.json
+++ b/boutiques_descriptors/qsiprep_v0_20_0.json
@@ -706,7 +706,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir", "qsiprep_html_report" ],

--- a/boutiques_descriptors/qsiprep_v0_21_4.json
+++ b/boutiques_descriptors/qsiprep_v0_21_4.json
@@ -741,7 +741,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir", "qsiprep_html_report", "recon_dir", "qsirecon_html_report",

--- a/boutiques_descriptors/qsiprep_v1.0.0.json
+++ b/boutiques_descriptors/qsiprep_v1.0.0.json
@@ -490,7 +490,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir"],

--- a/boutiques_descriptors/qsiprep_v1.0.0rc1.json
+++ b/boutiques_descriptors/qsiprep_v1.0.0rc1.json
@@ -490,7 +490,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "output_dir"],

--- a/boutiques_descriptors/qsirecon_v1.0.0.json
+++ b/boutiques_descriptors/qsirecon_v1.0.0.json
@@ -261,7 +261,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": ["recon_dir",

--- a/boutiques_descriptors/qsirecon_v1.0.0rc2.json
+++ b/boutiques_descriptors/qsirecon_v1.0.0rc2.json
@@ -261,7 +261,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>, Timothy Hendrickson <hendr522@umn.edu> and Natacha Beck <nbeck@mcin.ca>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": ["recon_dir",

--- a/boutiques_descriptors/symri_postproc_v1_0.json
+++ b/boutiques_descriptors/symri_postproc_v1_0.json
@@ -99,7 +99,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/symri_postproc_v1_1.json
+++ b/boutiques_descriptors/symri_postproc_v1_1.json
@@ -99,7 +99,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/symri_postproc_v1_2.json
+++ b/boutiques_descriptors/symri_postproc_v1_2.json
@@ -99,7 +99,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/symri_postproc_v1_3.json
+++ b/boutiques_descriptors/symri_postproc_v1_3.json
@@ -108,7 +108,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/symri_postproc_v1_3_1.json
+++ b/boutiques_descriptors/symri_postproc_v1_3_1.json
@@ -108,7 +108,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],

--- a/boutiques_descriptors/symri_qc_1_0.json
+++ b/boutiques_descriptors/symri_qc_1_0.json
@@ -92,7 +92,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:author": "Erik Lee <leex6144@umn.edu>",
         "cbrain:allow_empty_strings": ["derivatives_prefix"],
-        "cbrain:override-string-input-ruby-regex": {
+        "cbrain:override-input-string-ruby-regex": {
             "derivatives_prefix": ":relative-path:"
         },
         "cbrain:no-run-id-for-outputs": [ "OutputDirectory"],


### PR DESCRIPTION
CBRAIN imposed new sting parameter validation rules.

If a parameter may contain spaces it should be flagged as `:ids_with_spaces: ` 

